### PR TITLE
Add missing community docs and update ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,44 @@
+# Ignore files for .NET projects
 **/bin/
 **/obj/
+**/TestResults/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+.vs/
+
+# Ignore files for Node and Angular projects
+node_modules/
+dist/
+tmp/
+out-tsc/
+bazel-out/
+.angular/
+coverage/
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# IDE settings
+.idea/
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history/
+
+# Misc
+.sass-cache/
+connect.lock
+libpeerconnection.log
+typings/
+.DS_Store
+Thumbs.db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to Codex
+
+Thank you for taking the time to contribute! This project contains a .NET backend and an Angular frontend. The following guidelines help keep the workflow consistent for everyone.
+
+## Getting Started
+
+1. Fork the repository and create your feature branch from `main`.
+2. Install dependencies:
+   - Backend: use [.NET 8](https://dotnet.microsoft.com/) and run `dotnet restore`.
+   - Frontend: navigate to `client` and run `npm ci`.
+3. Make your changes and commit regularly with clear messages.
+
+## Running Tests
+
+Before opening a pull request, ensure that both backend and frontend tests pass:
+
+```bash
+# Backend tests
+dotnet test
+
+# Frontend tests
+cd client
+npm test -- --watch=false --browsers=ChromeHeadless
+```
+
+## Pull Requests
+
+- Ensure your PR describes the change and references any related issues.
+- Keep PRs focused and small when possible.
+- After tests succeed, open a pull request targeting the `main` branch.
+
+We appreciate your help in improving Codex!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Codex
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- extend `.gitignore` for .NET, Node, and Angular defaults
- add MIT `LICENSE`
- document contribution process in `CONTRIBUTING.md`

## Testing
- `npm install --legacy-peer-deps`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68407295928c8322a3c6a049d2000341